### PR TITLE
47:  Add tests for versions being set correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,16 +31,16 @@ jobs:
         GITHUB_TAG_VERSION: ${{ github.event.release.tag_name }}
       run: |
         python -m unittest discover test
-#    - name: Build package
-#      run: python -m build
-#    - name: Publish package
-#      uses: pypa/gh-action-pypi-publish@v1.8.14
-#      with:
-#        user: __token__
-#        password: ${{ secrets.PYPI_API_TOKEN }}
-#    - name: Create app tags
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      run: |
-#        export PYTHONPATH=.
-#        python .github/scripts/publish_app_tags.py
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@v1.8.14
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Create app tags
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        export PYTHONPATH=.
+        python .github/scripts/publish_app_tags.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,16 +31,16 @@ jobs:
         GITHUB_TAG_VERSION: ${{ github.event.release.tag_name }}
       run: |
         python -m unittest discover test
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.8.14
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-    - name: Create app tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        export PYTHONPATH=.
-        python .github/scripts/publish_app_tags.py
+#    - name: Build package
+#      run: python -m build
+#    - name: Publish package
+#      uses: pypa/gh-action-pypi-publish@v1.8.14
+#      with:
+#        user: __token__
+#        password: ${{ secrets.PYPI_API_TOKEN }}
+#    - name: Create app tags
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      run: |
+#        export PYTHONPATH=.
+#        python .github/scripts/publish_app_tags.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r .github/build_requirements.txt
+    - name: Run tests
+      env:
+        GITHUB_TAG_VERSION: ${{ github.event.release.tag_name }}
+      run: |
+        python -m unittest discover test
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,15 @@ name: Run Tests
 on:
   push:
     branches:
-      - "**" # Trigger on commits to any branch
+      - "**"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.10", "3.11" ]
-
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - "**" # Trigger on commits to any branch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.11" ]
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run Tests
+      run: |
+        python -m unittest discover test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "**"
+  workflow_dispatch:
+
 
 jobs:
   test:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-Version 0.0.5
+Version 2.3.0
 -------------
 45. Do no raise exception in telegram.end_call()
 43. Add guidelines on creating test data

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-Version 2.3.0
+Version 0.0.5
 -------------
 45. Do no raise exception in telegram.end_call()
 43. Add guidelines on creating test data

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,6 @@
 Version 2.3.0
 -------------
+47. Add tests for versions being set correctly
 45. Do no raise exception in telegram.end_call()
 43. Add guidelines on creating test data
 41. Add Google Maps documentation

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "0.0.5"
+version = "0.0.6"

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.2.1"
+version = "2.3.0"

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "0.0.6"
+version = "2.3.0"

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.3.0"
+version = "0.0.5"

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,28 @@
+import re
+import unittest
+from puma.utils import PROJECT_ROOT
+from puma.version import version
+
+
+def read_release_notes(file_path: str) -> [str]:
+    """
+    Read the content of the release notes file.
+    :param file_path: The path to the release notes file.
+    :return: The content of the release notes file.
+    """
+    with open(file_path, 'r') as file:
+        return file.readlines()
+
+
+class TestVersion(unittest.TestCase):
+    def setUp(self):
+        self.release_notes_path = f"{PROJECT_ROOT}/RELEASE_NOTES"
+        self.release_notes = read_release_notes(self.release_notes_path)
+
+    def test_version_in_release_notes_same_as_setup(self):
+        first_line = self.release_notes[0]
+        match = re.search(r'(\d+\.\d+\.\d+)', first_line)
+        first_version_in_release_notes = match.group(1) if match else None
+        self.assertIsNotNone(first_version_in_release_notes)
+        self.assertEqual(first_version_in_release_notes, version,
+                         "Version in release notes is not equal to setup version")

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -26,3 +26,7 @@ class TestVersion(unittest.TestCase):
         self.assertIsNotNone(first_version_in_release_notes)
         self.assertEqual(first_version_in_release_notes, version,
                          "Version in release notes is not equal to setup version")
+#TODO: add a workflow for test that is triggered upon commit
+# call this test from the publish yml so the tests are first run
+# ALso add release notes test?
+# Also add test to compare the release version in github with the release notes and version.py. Find out how to inject the release version from github in the script

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -2,7 +2,7 @@ import os
 import re
 import unittest
 from puma.utils import PROJECT_ROOT
-from puma.version import version
+from puma.version import version as setup_version
 
 
 def read_release_notes(file_path: str) -> [str]:
@@ -29,7 +29,7 @@ class TestVersion(unittest.TestCase):
 
     def test_version_in_release_notes_same_as_setup(self):
         self.assertIsNotNone(self.first_version_in_release_notes)
-        self.assertEqual(self.first_version_in_release_notes, version,
+        self.assertEqual(self.first_version_in_release_notes, setup_version,
                          "Version in release notes is not equal to setup version")
 
     def test_versions_same_as_github(self):
@@ -40,5 +40,5 @@ class TestVersion(unittest.TestCase):
 
         self.assertEqual(github_tag_version, self.first_version_in_release_notes,
                          "GitHub tag version is not equal to top version in release notes")
-        self.assertEqual(github_tag_version, version,
+        self.assertEqual(github_tag_version, setup_version,
                          "GitHub tag version is not equal to setup version")

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -43,7 +43,7 @@ class TestVersion(unittest.TestCase):
         if github_tag_version is None:
             self.skipTest("Skipping GitHub version test as no tag version was passed.")
 
-        self.assertEquals(github_tag_version, self.first_version_in_release_notes,
+        self.assertEqual(github_tag_version, self.first_version_in_release_notes,
                           "GitHub tag version is not equal to top version in release notes")
-        self.assertEquals(github_tag_version, version,
+        self.assertEqual(github_tag_version, version,
                           "GitHub tag version is not equal to setup version")

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -38,7 +38,7 @@ class TestVersion(unittest.TestCase):
                          "Version in release notes is not equal to setup version")
 
     def test_versions_same_as_github(self):
-        github_tag_version = os.getenv("$GITHUB_TAG_VERSION")
+        github_tag_version = os.getenv('GITHUB_TAG_VERSION')
         # Only run this test when a release is made from GitHub (i.e. the above environment variable is set)
         if github_tag_version is None:
             self.skipTest("Skipping GitHub version test as no tag version was passed.")

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -15,10 +15,6 @@ def read_release_notes(file_path: str) -> [str]:
         return file.readlines()
 
 
-def get_first_version_in_release_notes():
-    pass
-
-
 class TestVersion(unittest.TestCase):
 
     def setUp(self):
@@ -26,8 +22,7 @@ class TestVersion(unittest.TestCase):
         self.release_notes = read_release_notes(self.release_notes_path)
         self.first_version_in_release_notes = self._get_first_version_in_release_notes()
 
-
-    def _get_first_version_in_release_notes(self ):
+    def _get_first_version_in_release_notes(self):
         first_line = self.release_notes[0]
         match = re.search(r'(\d+\.\d+\.\d+)', first_line)
         return match.group(1) if match else None
@@ -44,6 +39,6 @@ class TestVersion(unittest.TestCase):
             self.skipTest("Skipping GitHub version test as no tag version was passed.")
 
         self.assertEqual(github_tag_version, self.first_version_in_release_notes,
-                          "GitHub tag version is not equal to top version in release notes")
+                         "GitHub tag version is not equal to top version in release notes")
         self.assertEqual(github_tag_version, version,
-                          "GitHub tag version is not equal to setup version")
+                         "GitHub tag version is not equal to setup version")


### PR DESCRIPTION
Here, we added tests to compare the version in version.py with the version in the release notes. This test will run on every push. 
 Moreover, a test was added to compare the aforementioned versions to the set tag version in a release. This will run before publishing the release. This test will be skipped if the tag name environment variable from github is not set. 