### PR TITLE
78: Fix Windows logging to file

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-Version 2.6.1
+Version 2.7.0
 -------------
 78. Fix Windows logging to file
 74. Create install scripts for Linux, MacOS, and Windows

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+Version 2.6.1
+-------------
+78. Fix Windows logging to file
+
 Version 2.6.0
 -------------
 75. Telegram: Fix sending messages and pictures for version 11.8.x

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,7 @@
 Version 2.6.1
 -------------
 78. Fix Windows logging to file
+74. Create install scripts for Linux, MacOS, and Windows
 
 Version 2.6.0
 -------------

--- a/puma/utils/__init__.py
+++ b/puma/utils/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
-from os import makedirs, environ
-from os.path import dirname, abspath, isdir, expanduser
+from os import makedirs
+from os.path import dirname, abspath
 from pathlib import Path
 from sys import stdout
 
@@ -22,7 +22,7 @@ makedirs(CACHE_FOLDER, exist_ok=True)
 
 # logging helpers
 def configure_default_logging():
-    now = datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+    now = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
     logging.basicConfig(
         handlers=[
             logging.FileHandler(Path(LOG_FOLDER) / f'{now}.log'),

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.6.0"
+version = "2.6.1"

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.6.1"
+version = "2.7.0"


### PR DESCRIPTION
Fix Windows logging to file by using `-` instead of `:`