### PR TITLE
PUMA-37: Change recognition of chat message EditText to use @hint

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,6 @@
 Version 2.7.0
 -------------
-89. Use hitn property instead of text property for finding Telegram chat EditText
+89. Use hint property instead of text property for finding Telegram chat EditText
 83. Remove old workshop folder
 81. Add section about problems with starting emulators to troubleshooting
 78. Fix Windows logging to file

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,6 @@
 Version 2.7.0
 -------------
+89. Use hitn property instead of text property for finding Telegram chat EditText
 83. Remove old workshop folder
 81. Add section about problems with starting emulators to troubleshooting
 78. Fix Windows logging to file

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -133,7 +133,7 @@ class TelegramActions(AndroidAppiumActions):
 
         # The actual send button is not in the same place as the element. The button is at about 75% of the box.
         # We adjust the location of the click from the middle to the right of the box.
-        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button
+        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button (issue 97)
         location = self._find_button_location(0.75, 0.5, '//android.view.View[@content-desc="Send"]')
         self.driver.tap([(location)])
 
@@ -229,7 +229,7 @@ class TelegramActions(AndroidAppiumActions):
         # press send
         # The actual send button is not in the same place as the element. The button is at about 75% of the box.
         # We adjust the location of the click from the middle to the right bottom corner of the box.
-        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button
+        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button (issue 97)
         location = self._find_button_location(0.75, 0.75, '//*[lower-case(@content-desc)="send"]')
         self.driver.tap([(location)])
 

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -9,7 +9,7 @@ TELEGRAM_PACKAGE = 'org.telegram.messenger'
 TELEGRAM_WEB_PACKAGE = 'org.telegram.messenger.web'
 
 
-@supported_version("11.8.3")
+@supported_version("11.9.0")
 class TelegramActions(AndroidAppiumActions):
 
     def __init__(self,

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -127,11 +127,13 @@ class TelegramActions(AndroidAppiumActions):
         :param chat: Optional: The chat conversation in which to send this message, if not currently in the desired chat
         """
         self._if_chat_go_to_chat(chat)
-        self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.EditText[@text="Message"]').send_keys(
-            message)
+        message_editText = self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.EditText[@hint="Message"]')
+        message_editText.clear()
+        message_editText.send_keys(message)
 
         # The actual send button is not in the same place as the element. The button is at about 75% of the box.
         # We adjust the location of the click from the middle to the right of the box.
+        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button
         location = self._find_button_location(0.75, 0.5, '//android.view.View[@content-desc="Send"]')
         self.driver.tap([(location)])
 
@@ -227,6 +229,7 @@ class TelegramActions(AndroidAppiumActions):
         # press send
         # The actual send button is not in the same place as the element. The button is at about 75% of the box.
         # We adjust the location of the click from the middle to the right bottom corner of the box.
+        # TODO: clicking the correct spot in the bounding box is no longer necessary because the click box is now the same size as the button
         location = self._find_button_location(0.75, 0.75, '//*[lower-case(@content-desc)="send"]')
         self.driver.tap([(location)])
 


### PR DESCRIPTION
Use the @hint attribute of the EditText to recognise the chat message EditText instead of @text attribute, and before entering text, clear the EditText first.