### PR TITLE
PUMA-38 Add support for selecting chat by index

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,6 @@
 Version 2.7.0
 -------------
-91. Add support for selecting chat by index
+91. Telegram: Add support for selecting chat by index
 83. Remove old workshop folder
 81. Add section about problems with starting emulators to troubleshooting
 78. Fix Windows logging to file

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,6 @@
 Version 2.7.0
 -------------
+91. Add support for selecting chat by index
 83. Remove old workshop folder
 81. Add section about problems with starting emulators to troubleshooting
 78. Fix Windows logging to file

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -93,15 +93,23 @@ class TelegramActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value=f'//android.view.ViewGroup[starts-with(lower-case(@text), "{chat.lower()}")]').click()
 
-    def select_chat(self, chat: str):
+    def select_chat(self, chat):
         """
-        Opens a given conversation based on the (partial) name of a chat.
+        Opens a given conversation based on the (partial) name of a chat, or opens the chat at the passed index
+        Note that the index is 1 based, so the first chat is index 1.
         For groups or channels, it is advised to use :meth:`TelegramActions.select_group` or
         :meth:`TelegramActions.select_channel`, as the matching is more explicit
         :param chat: (part of) the conversation name to open
         """
         self.return_to_homescreen()
-        xpath = f'//android.view.ViewGroup[starts-with(lower-case(@content-desc), "{chat.lower()}")]'
+        if type(chat) is str:
+            xpath = f'//android.view.ViewGroup[starts-with(lower-case(@content-desc), "{chat.lower()}")]'
+        elif type(chat) is int:
+            xpath = f'//androidx.recyclerview.widget.RecyclerView/android.view.ViewGroup[{chat}]'
+                      # //androidx.recyclerview.widget.RecyclerView/android.view.ViewGroup[1]
+        else:
+            raise ValueError(f'Argument was of type {type(chat)}, but needs to be str or int')
+
         self.driver.find_element(by=AppiumBy.XPATH, value=xpath).click()
         if not self._currently_in_conversation(implicit_wait=1):
             raise RuntimeError("Conversation was not opened after clicking the conversation")
@@ -120,7 +128,7 @@ class TelegramActions(AndroidAppiumActions):
         """
         self.select_chat(f'Channel. {channel_name}')
 
-    def send_message(self, message: str, chat: str = None):
+    def send_message(self, message: str, chat):
         """
         Send a message in the current or given chat
         :param message: The text message to send
@@ -328,7 +336,7 @@ class TelegramActions(AndroidAppiumActions):
             raise Exception('Expected to be in a call, but could not detect call screen!')
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.FrameLayout[@content-desc="Flip"]').click()
 
-    def _if_chat_go_to_chat(self, chat: str):
+    def _if_chat_go_to_chat(self, chat):
         if chat is not None:
             self.select_chat(chat)
             sleep(1)

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -99,14 +99,13 @@ class TelegramActions(AndroidAppiumActions):
         Note that the index is 1 based, so the first chat is index 1.
         For groups or channels, it is advised to use :meth:`TelegramActions.select_group` or
         :meth:`TelegramActions.select_channel`, as the matching is more explicit
-        :param chat: (part of) the conversation name to open
+        :param chat: (part of) the conversation name to open or the index of the chat to open
         """
         self.return_to_homescreen()
         if type(chat) is str:
             xpath = f'//android.view.ViewGroup[starts-with(lower-case(@content-desc), "{chat.lower()}")]'
         elif type(chat) is int:
             xpath = f'//androidx.recyclerview.widget.RecyclerView/android.view.ViewGroup[{chat}]'
-                      # //androidx.recyclerview.widget.RecyclerView/android.view.ViewGroup[1]
         else:
             raise ValueError(f'Argument was of type {type(chat)}, but needs to be str or int')
 

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -93,13 +93,13 @@ class TelegramActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value=f'//android.view.ViewGroup[starts-with(lower-case(@text), "{chat.lower()}")]').click()
 
-    def select_chat(self, chat):
+    def select_chat(self, chat: str | int):
         """
         Opens a given conversation based on the (partial) name of a chat, or opens the chat at the passed index
         Note that the index is 1 based, so the first chat is index 1.
         For groups or channels, it is advised to use :meth:`TelegramActions.select_group` or
         :meth:`TelegramActions.select_channel`, as the matching is more explicit
-        :param chat: (part of) the conversation name to open or the index of the chat to open
+        :param chat: (part of) the conversation name to open or the 1-based index of the chat to open
         """
         self.return_to_homescreen()
         if type(chat) is str:
@@ -127,11 +127,11 @@ class TelegramActions(AndroidAppiumActions):
         """
         self.select_chat(f'Channel. {channel_name}')
 
-    def send_message(self, message: str, chat):
+    def send_message(self, message: str, chat: str | int):
         """
         Send a message in the current or given chat
         :param message: The text message to send
-        :param chat: Optional: The chat conversation in which to send this message, if not currently in the desired chat
+        :param chat: Optional: The chat conversation in which to send this message, if not currently in the desired chat. This is either the (partial) chat name or the index of the chat on the home screen.
         """
         self._if_chat_go_to_chat(chat)
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.EditText[@text="Message"]').send_keys(
@@ -335,7 +335,7 @@ class TelegramActions(AndroidAppiumActions):
             raise Exception('Expected to be in a call, but could not detect call screen!')
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.FrameLayout[@content-desc="Flip"]').click()
 
-    def _if_chat_go_to_chat(self, chat):
+    def _if_chat_go_to_chat(self, chat: str | int):
         if chat is not None:
             self.select_chat(chat)
             sleep(1)

--- a/test_scripts/test_telegram.py
+++ b/test_scripts/test_telegram.py
@@ -125,6 +125,9 @@ class TestTelegram(unittest.TestCase):
         time.sleep(1)
         self.bob.end_call()
 
+    def test_select_chat_by_index(self):
+        self.alice.select_chat(1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added support for selecting a chat by index. It is now possible to use either a string or an integer in the select_chat function. Based on the type of the input, the correct xpath for the desired element is created. A ValueError is thrown when something is passed to this function when something different than a string or integer is passed.