### PR TITLE
110 add ground truth logging functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Puma uses Python’s standard `logging` library.
 
 - **As a CLI or main module:** Puma configures default logging so INFO and higher messages are visible.
 - **In Jupyter notebooks:** Puma enables default logging so logs are visible in notebook cells.
-- **As a library:** Puma does not configure logging; messages are only shown if your application configures logging.
+- **As a module in another project:** Puma does not configure logging; messages are only shown if your application configures logging.
 
 ### How to See Puma’s Logs
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The code below shows a small example on how to search for the Eiffel Tower in Go
 
 ```python
 from puma.apps.android.google_maps.google_maps import GoogleMapsActions
+from puma.utils import configure_default_logging
+
+configure_default_logging()# Use Puma's logging configuration. You can also implement your own
 
 phone = GoogleMapsActions("emulator-5444")
 phone.search_place('eiffel tower')
@@ -72,6 +75,9 @@ with the code below:
 
 ```python
 from puma.apps.android.whatsapp.whatsapp import WhatsappActions
+from puma.utils import configure_default_logging
+
+configure_default_logging() # Use Puma's logging configuration. You can also implement your own
 
 alice = WhatsappActions("<INSERT UDID HERE>")  # Initialize a connection with device
 alice.create_new_chat(contact="<Insert the contact name>",
@@ -132,7 +138,9 @@ most methods give you the option to navigate to a specific conversation. 2 examp
 
 ```python
 from puma.apps.android.whatsapp.whatsapp import WhatsappActions
+from puma.utils import configure_default_logging
 
+configure_default_logging() # Use Puma's logging configuration. You can also implement your own
 alice = WhatsappActions("emulator-5554")  # initialize a connection with device emulator-5554
 alice.select_chat("Bob")
 alice.send_message("message_text")
@@ -145,7 +153,9 @@ are in the correct conversation. So, you will have to have called `select_chat` 
 
 ```python
 from puma.apps.android.whatsapp.whatsapp import WhatsappActions
+from puma.utils import configure_default_logging
 
+configure_default_logging() # Use Puma's logging configuration. You can also implement your own
 alice = WhatsappActions("emulator-5554")  # initialize a connection with device emulator-5554
 alice.send_message("message_text", chat="Bob")
 ```
@@ -225,6 +235,28 @@ sudo apt install ffmpeg
 
 This utils code offers a way to process screen recordings (namely concatenating videos and stitching them together
 horizontally).
+
+## Logging in Puma
+
+Puma uses Python’s standard `logging` library.
+
+### Default Behavior
+
+- **As a CLI or main module:** Puma configures default logging so INFO and higher messages are visible.
+- **In Jupyter notebooks:** Puma enables default logging so logs are visible in notebook cells.
+- **As a library:** Puma does not configure logging; messages are only shown if your application configures logging.
+
+### How to See Puma’s Logs
+
+To see Puma logs in your own script, opt-in to Puma's default log format and level by calling:
+
+```python
+from puma.utils import configure_default_logging
+configure_default_logging()
+```
+
+This is also shown in the examples above.
+If you want to use your own logging format, you can configure Python logging (e.g., with `logging.basicConfig(level=logging.INFO)`).
 
 ## Troubleshooting
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+Version 2.9.0
+-------------
+110. Add ground truth logging
+
 Version 2.8.0
 -------------
 108. Update setuptools dependency

--- a/install/macos/install_adb.sh
+++ b/install/macos/install_adb.sh
@@ -18,7 +18,7 @@ echo "Setting environment variables"
 
 current_dir=$(dirname "$(realpath "$0")")
 source "$current_dir"/../common/get_shell.sh
-SHELL_PROFILE=$(shell_profile)
+SHELL_PROFILE=$(shell_profile) #TODO this does not work on Mac
 
 if [ -n "$SHELL_PROFILE" ]; then
     # Check if variables already exist in the profile
@@ -60,3 +60,5 @@ unzip -q "$TEMP_DIR"/platform-tools.zip -d "$ANDROID_SDK_DIR"
 
 echo "Cleaning up temporary files..."
 rm -rf "$TEMP_DIR"
+
+#TODO adb to path

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -1,4 +1,36 @@
+import logging
+import sys
+
 from puma.utils import configure_default_logging
 
-# turn off default logging config for now, as it overwrites the config of projects using Puma.
-# configure_default_logging()
+MAIN_MODULE = sys.modules.get('__main__')
+
+def pattern_in_main(pattern):
+    if hasattr(MAIN_MODULE, '__file__'):
+        return MAIN_MODULE and pattern in MAIN_MODULE.__file__
+    return False
+
+def _is_running_as_main() -> bool:
+    """
+    Returns True if this package is being run as the main module
+    via `python -m puma`.
+    """
+    return pattern_in_main('puma/apps')
+
+def _is_running_as_test() -> bool:
+    return pattern_in_main('unittest_runner')
+
+def _is_running_in_jupyter_notebook():
+    if MAIN_MODULE is not None:
+        if not hasattr(MAIN_MODULE, '__file__'):
+            return True
+        if 'ipykernel' in str(type(MAIN_MODULE)):
+            return True
+    return False
+
+# Only configure logging when Puma is not run from another application
+if _is_running_as_main() or _is_running_as_test() or _is_running_in_jupyter_notebook():
+        configure_default_logging()
+else:
+    logger = logging.getLogger("puma")
+    logger.addHandler(logging.NullHandler())

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -5,7 +5,7 @@ from puma.utils import configure_default_logging
 
 MAIN_MODULE = sys.modules.get('__main__')
 
-def pattern_in_main(pattern):
+def _pattern_in_main(pattern):
     if hasattr(MAIN_MODULE, '__file__'):
         return MAIN_MODULE and pattern in MAIN_MODULE.__file__
     return False
@@ -15,10 +15,10 @@ def _is_running_as_main() -> bool:
     Returns True if this package is being run as the main module
     via `python -m puma`.
     """
-    return pattern_in_main('puma/apps')
+    return _pattern_in_main('puma/apps')
 
 def _is_running_as_test() -> bool:
-    return pattern_in_main('unittest_runner')
+    return _pattern_in_main('unittest_runner')
 
 def _is_running_in_jupyter_notebook():
     if MAIN_MODULE is not None:
@@ -28,8 +28,15 @@ def _is_running_in_jupyter_notebook():
             return True
     return False
 
+
+configure_default_logging()
+
 # Only configure logging when Puma is not run from another application
-if _is_running_as_main() or _is_running_as_test() or _is_running_in_jupyter_notebook():
+if (
+        _is_running_as_main() or
+        _is_running_as_test() or
+        _is_running_in_jupyter_notebook()
+):
         configure_default_logging()
 else:
     logger = logging.getLogger("puma")

--- a/puma/apps/android/__init__.py
+++ b/puma/apps/android/__init__.py
@@ -1,3 +1,12 @@
+import functools
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+def log_action(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        logger.info(f"Action {func.__name__} initiated at {datetime.now().isoformat()}")
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/puma/apps/android/__init__.py
+++ b/puma/apps/android/__init__.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 def log_action(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        logger.info(f"Action {func.__name__} initiated at {datetime.now().isoformat()}")
+        module_name = func.__module__
+        logger = logging.getLogger(module_name)
+        logger.info(f"Action {func.__name__} initiated")
         return func(self, *args, **kwargs)
     return wrapper

--- a/puma/apps/android/appium_actions.py
+++ b/puma/apps/android/appium_actions.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 import time

--- a/puma/apps/android/google_camera/google_camera.py
+++ b/puma/apps/android/google_camera/google_camera.py
@@ -22,6 +22,7 @@ class GoogleCameraActions(AndroidAppiumActions):
                                       implicit_wait=implicit_wait,
                                       appium_server=appium_server)
 
+    @log_action
     def take_picture(self):
         """
         Takes a single picture.
@@ -29,6 +30,7 @@ class GoogleCameraActions(AndroidAppiumActions):
         xpath = '//android.widget.ImageButton[@resource-id="com.google.android.GoogleCamera:id/shutter_button"]'
         shutter = self.driver.find_element(by=AppiumBy.XPATH, value=xpath)
         shutter.click()
+
     @log_action
     def switch_camera(self):
         """

--- a/puma/apps/android/google_camera/google_camera.py
+++ b/puma/apps/android/google_camera/google_camera.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action, logger
 from puma.apps.android.appium_actions import AndroidAppiumActions, supported_version
 
 GOOGLE_CAMERA_PACKAGE = 'com.google.android.GoogleCamera'
@@ -28,7 +29,7 @@ class GoogleCameraActions(AndroidAppiumActions):
         xpath = '//android.widget.ImageButton[@resource-id="com.google.android.GoogleCamera:id/shutter_button"]'
         shutter = self.driver.find_element(by=AppiumBy.XPATH, value=xpath)
         shutter.click()
-
+    @log_action
     def switch_camera(self):
         """
         Switches between the front and rear camera.

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import AndroidAppiumActions, supported_version
 
 GOOGLE_CHROME_PACKAGE = 'com.android.chrome'
@@ -20,6 +21,7 @@ class GoogleChromeActions(AndroidAppiumActions):
                                       implicit_wait=impicit_wait,
                                       appium_server=appium_server)
 
+    @log_action
     def go_to(self, url_string: str, new_tab: bool = False):
         """
         Enters the text as stated in the url_string parameter.
@@ -44,6 +46,7 @@ class GoogleChromeActions(AndroidAppiumActions):
         url_bar.send_keys(url_string)
         self.driver.press_keycode(66)
 
+    @log_action
     def bookmark_page(self):
         """
         Bookmarks the current page.
@@ -53,6 +56,7 @@ class GoogleChromeActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH, value=three_dots_xpath).click()
         self.driver.find_element(by=AppiumBy.XPATH, value=bookmark_xpath).click()
 
+    @log_action
     def load_bookmark(self):
         """
         Load the first saved bookmark in the folder 'Mobile Bookmarks'.
@@ -67,6 +71,7 @@ class GoogleChromeActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.XPATH, value=mobile_bookmarks_xpath).click()
         self.driver.find_element(by=AppiumBy.XPATH, value=first_bookmark_xpath).click()
 
+    @log_action
     def switch_to_tab(self, num_tab: int = 1):
         """
         Switches to another tab, by default the first open tab.
@@ -76,6 +81,7 @@ class GoogleChromeActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH, value=switch_tab_xpath).click()
         self.driver.find_element(by=AppiumBy.XPATH, value=f'(//android.widget.FrameLayout[@resource-id="com.android.chrome:id/content_view"])[{num_tab}]').click()
 
+    @log_action
     def go_to_incognito(self, url_string: str):
         """
         Opens an incognito window and enters the url_string to the address bar.

--- a/puma/apps/android/google_maps/google_maps.py
+++ b/puma/apps/android/google_maps/google_maps.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import AndroidAppiumActions, supported_version
 from puma.utils.route_simulator import RouteSimulator
 
@@ -39,6 +40,7 @@ class GoogleMapsActions(AndroidAppiumActions):
             if not self.app_open():
                 self.activate_app()
 
+    @log_action
     def search_place(self, search_string: str):
         self._ensure_at_start()
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.TextView[@text="Search here"]').click()
@@ -47,6 +49,7 @@ class GoogleMapsActions(AndroidAppiumActions):
         first_result = '//android.support.v7.widget.RecyclerView[@resource-id="com.google.android.apps.maps:id/typed_suggest_container"]/android.widget.LinearLayout[1]'
         self.driver.find_element(by=AppiumBy.XPATH, value=first_result).click()
 
+    @log_action
     def start_navigation(self, search_string: str, transport_type: TransportType = TransportType.CAR, time_to_wait=10):
         self.search_place(search_string)
         directions_xpath = '//android.widget.Button[starts-with(@content-desc, "Directions to")]'
@@ -71,6 +74,7 @@ class GoogleMapsActions(AndroidAppiumActions):
                 sleep(1)
         raise Exception(f'Route was not loaded after {time_to_wait} seconds')
 
+    @log_action
     def start_route(self, from_query: str, to_query: str, speed: int,
                     transport_type: TransportType = TransportType.CAR):
         self.route_simulator.update_speed(0)

--- a/puma/apps/android/open_camera/open_camera.py
+++ b/puma/apps/android/open_camera/open_camera.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import AndroidAppiumActions, supported_version
 
 OPEN_CAMERA_PACKAGE = 'net.sourceforge.opencamera'
@@ -48,6 +49,7 @@ class OpenCameraActions(AndroidAppiumActions):
             button = self.driver.find_element(by=AppiumBy.XPATH, value=video_mode_button)
             button.click()
 
+    @log_action
     def take_picture(self):
         """
         Takes a picture.
@@ -55,6 +57,7 @@ class OpenCameraActions(AndroidAppiumActions):
         self._switch_to_photo_mode()
         self._click_shutter()
 
+    @log_action
     def switch_camera(self):
         """
         Switches between the front and back camera.
@@ -63,6 +66,7 @@ class OpenCameraActions(AndroidAppiumActions):
         switch_camera_button = self.driver.find_element(by=AppiumBy.XPATH, value=xpath)
         switch_camera_button.click()
 
+    @log_action
     def take_video(self, duration: int):
         """
         Takes a video of a given duration.
@@ -74,6 +78,7 @@ class OpenCameraActions(AndroidAppiumActions):
         finally:
             self._click_shutter()
 
+    @log_action
     def zoom(self, zoom_amount: float):
         """
         Zooms to a given level between 0.0 (zoomed out completely) and 1.0 (zoomed in completely).

--- a/puma/apps/android/snapchat/snapchat.py
+++ b/puma/apps/android/snapchat/snapchat.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import AndroidAppiumActions, supported_version
 
 SNAPCHAT_PACKAGE = 'com.snapchat.android'
@@ -75,6 +76,7 @@ class SnapchatActions(AndroidAppiumActions):
                                  value=f'//android.widget.LinearLayout[@resource-id="com.snapchat.android:id/ngs_navigation_bar"]/android.view.ViewGroup[@content-desc="{tab_name}"]').click()
 
     # TODO create a separate function for each tab, so the user cannot make any typos
+    @log_action
     def go_to_conversation_tab(self):
         """
         Navigate to the top of the conversation tab.
@@ -87,6 +89,7 @@ class SnapchatActions(AndroidAppiumActions):
         if not self._currently_on_top_of_conversation_overview():
             self._go_to_main_tab("Chat")
 
+    @log_action
     def go_to_camera_tab(self):
         """
         Navigate to camera tab.
@@ -94,6 +97,7 @@ class SnapchatActions(AndroidAppiumActions):
         if not self._currently_in_camera_tab():
             self._go_to_main_tab("Camera")
 
+    @log_action
     def select_chat(self, chat_subject: str):
         """
         Opens a given conversation.
@@ -110,6 +114,7 @@ class SnapchatActions(AndroidAppiumActions):
         if not self._currently_in_conversation():
             raise Exception('Expected to be in conversation screen now, but screen contents are unknown')
 
+    @log_action
     def send_message(self, message: str, chat: str = None):
         """
         Sends a text message, either in the current conversation, or in a given conversation.
@@ -127,6 +132,7 @@ class SnapchatActions(AndroidAppiumActions):
         enter_keycode = 66
         self.driver.press_keycode(enter_keycode)
 
+    @log_action
     def send_snap(self, recipients: [str] = None, caption: str = None, front_camera: bool = True):
         """
         Sends a snap (picture), either to one or more contacts, or posts it to `My story`

--- a/puma/apps/android/telegram/telegram.py
+++ b/puma/apps/android/telegram/telegram.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import supported_version, AndroidAppiumActions
 
 TELEGRAM_PACKAGE = 'org.telegram.messenger'
@@ -82,6 +83,7 @@ class TelegramActions(AndroidAppiumActions):
         self._load_conversation_titles()
         sleep(1)
 
+    @log_action
     def start_new_chat(self, chat: str):
         self.return_to_homescreen()
         self.driver.find_element(by=AppiumBy.XPATH,
@@ -93,6 +95,7 @@ class TelegramActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value=f'//android.view.ViewGroup[starts-with(lower-case(@text), "{chat.lower()}")]').click()
 
+    @log_action
     def select_chat(self, chat: str | int):
         """
         Opens a given conversation based on the (partial) name of a chat, or opens the chat at the passed index
@@ -113,6 +116,7 @@ class TelegramActions(AndroidAppiumActions):
         if not self._currently_in_conversation(implicit_wait=1):
             raise RuntimeError("Conversation was not opened after clicking the conversation")
 
+    @log_action
     def select_group(self, group_name: str):
         """
         Opens a given conversation based on the exact name of a group.
@@ -120,6 +124,7 @@ class TelegramActions(AndroidAppiumActions):
         """
         self.select_chat(f'Group. {group_name}')
 
+    @log_action
     def select_channel(self, channel_name: str):
         """
         Opens a given conversation based on the exact name of a channel.
@@ -127,6 +132,7 @@ class TelegramActions(AndroidAppiumActions):
         """
         self.select_chat(f'Channel. {channel_name}')
 
+    @log_action
     def send_message(self, message: str, chat: str | int):
         """
         Send a message in the current or given chat
@@ -145,6 +151,7 @@ class TelegramActions(AndroidAppiumActions):
         location = self._find_button_location(0.75, 0.5, '//android.view.View[@content-desc="Send"]')
         self.driver.tap([(location)])
 
+    @log_action
     def reply_to_message(self, message_to_reply_to: str, reply: str, chat: str = None):
         """
         Send a text message as a reply to a previous message.
@@ -161,6 +168,7 @@ class TelegramActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.EditText').send_keys(reply)
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.view.View[@content-desc="Send"]').click()
 
+    @log_action
     def emoji_reply_to_message(self, message_to_respond_to: str, emoji_to_respond_with: str = '👍', chat: str = None):
         """
         Send emoji response to a previous message.
@@ -186,6 +194,7 @@ class TelegramActions(AndroidAppiumActions):
         print(f'Tapping screen at ({x},{y})')
         self.driver.tap([(x, y)])
 
+    @log_action
     def take_and_send_picture(self,
                               chat: str = None,
                               caption: str = None,
@@ -243,6 +252,7 @@ class TelegramActions(AndroidAppiumActions):
 
         sleep(0.3)  # the animation after sending a picture might throw off the script
 
+    @log_action
     def start_call(self, chat: str = None, video: bool = False) -> bool:
         """
         Makes a call and ends the call after a given number of seconds.
@@ -265,6 +275,7 @@ class TelegramActions(AndroidAppiumActions):
         # wait a short while (max 2s) for the call to have started
         return self._currently_in_call(implicit_wait=2)
 
+    @log_action
     def get_call_status(self) -> Optional[str]:
         """
         Returns a string describing the status of the current call, which is a text visible on the call screen.
@@ -280,6 +291,7 @@ class TelegramActions(AndroidAppiumActions):
         status_element = self.driver.find_element(by=AppiumBy.XPATH, value=status_element)
         return status_element.get_attribute("text")
 
+    @log_action
     def end_call(self):
         """
         Ends the current call. Assumes the call screen is open.
@@ -289,6 +301,7 @@ class TelegramActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value='//android.widget.Button[lower-case(@text)="end call"]').click()
 
+    @log_action
     def answer_call(self):
         """
         Answer when receiving a call via Telegram.
@@ -303,6 +316,7 @@ class TelegramActions(AndroidAppiumActions):
         if self.is_present(open_call_button):
             self.driver.find_element(by=AppiumBy.XPATH, value=open_call_button).click()
 
+    @log_action
     def decline_call(self):
         """
         Declines an incoming Telegram call.
@@ -315,6 +329,7 @@ class TelegramActions(AndroidAppiumActions):
                                  value='//android.widget.Button[lower-case(@content-desc)="decline"]').click()
         self.driver.back()
 
+    @log_action
     def toggle_video_in_call(self):
         """
         Toggles video in an ongoing call.
@@ -331,6 +346,7 @@ class TelegramActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.XPATH,
                                      value='//android.widget.FrameLayout[@content-desc="Stop Video"]').click()
 
+    @log_action
     def flip_video_in_call(self):
         """
         Switches between the front camera and rear camera while in a video call.

--- a/puma/apps/android/teleguard/teleguard.py
+++ b/puma/apps/android/teleguard/teleguard.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from appium.webdriver.common.appiumby import AppiumBy
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import supported_version, AndroidAppiumActions
 from puma.apps.android.teleguard import logger
 
@@ -41,7 +42,6 @@ class TeleguardActions(AndroidAppiumActions):
             if not self._currently_in_conversation(chat):
                 raise Exception('Expected to be in conversation screen now, but screen contents are unknown')
 
-
     def _currently_at_homescreen(self) -> bool:
         """
         Check whether currently at homescreen of the application.
@@ -73,6 +73,7 @@ class TeleguardActions(AndroidAppiumActions):
             raise Exception('Tried to return to homescreen but ran out of attempts...')
         sleep(0.5)
 
+    @log_action
     def select_chat(self, chat: str):
         """
         Opens a given conversation based on the (partial) name of a chat.
@@ -85,6 +86,7 @@ class TeleguardActions(AndroidAppiumActions):
 
         self.driver.find_element(by=AppiumBy.XPATH, value=xpath).click()
 
+    @log_action
     def send_message(self, message: str, chat: str = None):
         """
         Send a message in the current or given chat.
@@ -99,6 +101,7 @@ class TeleguardActions(AndroidAppiumActions):
         text_box_el.send_keys(message)
         self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.FrameLayout[@resource-id="android:id/content"]/android.widget.FrameLayout/android.widget.FrameLayout/android.view.View/android.view.View/android.view.View/android.view.View/android.widget.ImageView[3]').click()
 
+    @log_action
     def add_contact(self, id: str):
         """
         Add a contact by TeleGuard ID.
@@ -114,6 +117,7 @@ class TeleguardActions(AndroidAppiumActions):
         invite_btn = self.driver.find_element(by=AppiumBy.XPATH, value='//android.widget.Button[@content-desc="INVITE"]')
         invite_btn.click()
 
+    @log_action
     def accept_invite(self):
         """
         Accept an invite from another user. If you have multiple invites, only one invite will be accepted (the topmost

--- a/puma/apps/android/whatsapp/whatsapp.py
+++ b/puma/apps/android/whatsapp/whatsapp.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Union
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.common.by import By
 
+from puma.apps.android import log_action
 from puma.apps.android.appium_actions import supported_version, AndroidAppiumActions
 
 WHATSAPP_PACKAGE = 'com.whatsapp'
@@ -51,6 +52,7 @@ class WhatsappActions(AndroidAppiumActions):
         return self.driver.find_elements(by=AppiumBy.XPATH,
                                          value=f"//*[contains(@resource-id,'com.whatsapp:id/conversations_row_contact_name') and @text='{subject}']")
 
+    @log_action
     def select_chat(self, subject):
         """
         Select the chat with subject x. For 1-on-1 chats, the subject is the name of the conversation partner. For group
@@ -66,6 +68,7 @@ class WhatsappActions(AndroidAppiumActions):
             raise Exception(f'Cannot find conversation with name {subject}')
         chats_of_interest[0].click()
 
+    @log_action
     def create_new_chat(self, contact, first_message):
         """
         Start a new 1-on-1 conversation with a contact and send a message.
@@ -86,6 +89,7 @@ class WhatsappActions(AndroidAppiumActions):
         if not self.currently_in_conversation():
             raise Exception('Expected to be in conversation screen now, but screen contents are unknown')
 
+    @log_action
     def send_message(self, message_text, chat: str = None, wait_until_sent=False):
         """
         Send a message in the current chat. If the message contains a mention, this is handled correctly.
@@ -142,6 +146,7 @@ class WhatsappActions(AndroidAppiumActions):
             sleep(10)
         return message_status_el
 
+    @log_action
     def delete_message_for_everyone(self, message_text: str, chat: str = None):
         """
         Remove a message with the message text. Should be recently sent, so it is still in view and still possible to
@@ -158,6 +163,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value="//*[@resource-id='com.whatsapp:id/buttonPanel']//*[@text='Delete for everyone']").click()
 
+    @log_action
     def reply_to_message(self, message_to_reply_to: str, reply_text: str, chat: str = None):
         """
         Reply to a message. Assumes you are in the chat in which the message was sent.
@@ -175,6 +181,7 @@ class WhatsappActions(AndroidAppiumActions):
         text_box.send_keys(reply_text)
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send").click()
 
+    @log_action
     def send_broadcast(self, receivers: [str], broadcast_text: str):
         """
         Broadcast a message.
@@ -197,6 +204,7 @@ class WhatsappActions(AndroidAppiumActions):
         text_box.send_keys(broadcast_text)
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send").click()
 
+    @log_action
     def send_media(self, directory_name, caption=None, view_once=False, chat: str = None):
         """
         Send a photo or video with or without a caption in the current chat.
@@ -246,6 +254,7 @@ class WhatsappActions(AndroidAppiumActions):
         sleep(1)
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send").click()
 
+    @log_action
     def send_sticker(self, chat: str = None):
         """
         Send the only sticker in the sticker menu. Assumes 1 sticker is present in WhatsApp.
@@ -268,6 +277,7 @@ class WhatsappActions(AndroidAppiumActions):
     def _click_coordinates(self, x, y):
         self.driver.execute_script('mobile: clickGesture', {'x': x, 'y': y})
 
+    @log_action
     def send_voice_recording(self, duration: int = 2000, chat: str = None):
         """
         Sends a voice message in the current conversation.
@@ -279,6 +289,7 @@ class WhatsappActions(AndroidAppiumActions):
         voice_button = self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/voice_note_btn")
         self._long_press_element(voice_button, duration=duration)
 
+    @log_action
     def send_current_location(self, chat: str = None):
         """
         Send the current location in the current chat.
@@ -291,6 +302,7 @@ class WhatsappActions(AndroidAppiumActions):
         sleep(5)  # it takes some time to fix the location
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send_current_location_btn").click()
 
+    @log_action
     def send_live_location(self, caption=None, chat: str = None):
         """
         Send a live location in the current chat.
@@ -309,6 +321,7 @@ class WhatsappActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/comment").send_keys(caption)
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send").click()
 
+    @log_action
     def stop_live_location(self, need_to_scroll=False, chat: str = None):
         """
         Stops the current live location sharing.
@@ -325,6 +338,7 @@ class WhatsappActions(AndroidAppiumActions):
         if self.is_present(popup_button_xpath):
             self.driver.find_element(by=AppiumBy.XPATH, value=popup_button_xpath).click()
 
+    @log_action
     def send_contact(self, contact_name: str, chat: str = None):
         """
         Send a contact in the current chat.
@@ -339,6 +353,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/next_btn").click()
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send_btn").click()
 
+    @log_action
     def change_profile_picture(self, photo_dir_name: str = "profile_picture"):
         """
         Change profile picture. Selects the picture in the specified directory.
@@ -356,6 +371,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=By.CLASS_NAME, value="android.widget.ImageView").click()
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/ok_btn").click()
 
+    @log_action
     def set_status(self, caption: str = None):
         """
         Sets a status by taking a picture and setting the given caption.
@@ -379,6 +395,7 @@ class WhatsappActions(AndroidAppiumActions):
         # TODO: popup that can appear!
         self.return_to_homescreen()
 
+    @log_action
     def set_about(self, about_text: str):
         """
         Set the about section on the WhatsApp profile.
@@ -394,6 +411,7 @@ class WhatsappActions(AndroidAppiumActions):
         text_box.send_keys(about_text)
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/save_button").click()
 
+    @log_action
     def activate_disappearing_messages(self, chat=None):
         """
         Activates disappearing messages (auto delete) in the current or a given chat.
@@ -412,6 +430,7 @@ class WhatsappActions(AndroidAppiumActions):
         else:
             self.return_to_homescreen()
 
+    @log_action
     def deactivate_disappearing_messages(self, chat=None):
         """
         Disables disappearing messages (auto delete) in the current or a given chat.
@@ -429,6 +448,7 @@ class WhatsappActions(AndroidAppiumActions):
         else:
             self.return_to_homescreen()
 
+    @log_action
     def navigate_to_call_tab(self):
         """
         Navigates to the call tab. The 2 resource ids are necessary because they differ when you are or are not on the call tab.
@@ -440,6 +460,7 @@ class WhatsappActions(AndroidAppiumActions):
                                        'or @resource-id="com.whatsapp:id/navigation_bar_item_large_label_view" )'
                                        'and @text="Calls"]').click()
 
+    @log_action
     def call_contact(self, contact, video_call=False):
         """
         Make a WhatsApp call. The call is made to a given contact name
@@ -457,6 +478,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value=f'(//android.widget.ImageView[@content-desc="{call_type}"])[1]').click()  # Take the top one without checking the name, since we already searched for the contact
 
+    @log_action
     def end_call(self):
         """
         Ends the current call. Assumes the call screen is open.
@@ -468,6 +490,7 @@ class WhatsappActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.XPATH, value=background).click()
         self.driver.find_element(by=AppiumBy.XPATH, value=end_call_button).click()
 
+    @log_action
     def answer_call(self):
         """
         Answer when receiving a call via Whatsapp.
@@ -477,6 +500,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value="//android.widget.Button[@content-desc='Answer' or @content-desc='Video']").click()
 
+    @log_action
     def decline_call(self):
         """
         Declines an incoming Whatsapp call.
@@ -485,6 +509,7 @@ class WhatsappActions(AndroidAppiumActions):
         sleep(2)
         self.driver.find_element(by=AppiumBy.XPATH, value="//android.widget.Button[@content-desc='Decline']").click()
 
+    @log_action
     def create_group(self, subject: str, participants: Union[str, List[str]]):
         """
         Create a new group. Assumes you are in homescreen.
@@ -528,6 +553,7 @@ class WhatsappActions(AndroidAppiumActions):
                         f"Could not create group after 20 attempts. Try restarting your emulator and try again.")
         self.return_to_homescreen()
 
+    @log_action
     def set_group_description(self, group_name, description):
         """
         Set the group description.
@@ -542,6 +568,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/ok_btn").click()
         self.return_to_homescreen()
 
+    @log_action
     def delete_group(self, group_name):
         """
         Leaves and deletes a given group.
@@ -555,6 +582,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH, value="//*[contains(@text,'Delete group')]").click()
         self.return_to_homescreen()
 
+    @log_action
     def archive_conversation(self, subject):
         """
         Archives a given conversation.
@@ -588,6 +616,7 @@ class WhatsappActions(AndroidAppiumActions):
         y = location['y'] + size['height'] // 2
         self.driver.execute_script('mobile: longClickGesture', {'x': x, 'y': y, 'duration': duration})
 
+    @log_action
     def leave_group(self, group_name):
         """
         This method will leave the given group. It will not delete that group.
@@ -600,6 +629,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH, value="//android.widget.Button[@text='Exit']").click()
         self.return_to_homescreen()
 
+    @log_action
     def remove_participant_from_group(self, group_name, participant):
         """
         Removes a given participant from a given group chat.
@@ -615,6 +645,7 @@ class WhatsappActions(AndroidAppiumActions):
         sleep(5)
         self.return_to_homescreen()
 
+    @log_action
     def forward_message(self, from_chat, message_contains, to_chat):
         """
         Forwards a message from one conversation to another.
@@ -634,6 +665,7 @@ class WhatsappActions(AndroidAppiumActions):
         f"//*[@resource-id='com.whatsapp:id/contact_list']//*[@text='{to_chat}']").click()
         self.driver.find_element(by=AppiumBy.ID, value="com.whatsapp:id/send").click()
 
+    @log_action
     def open_settings_you(self):
         """
         Open personal settings (or profile).
@@ -645,6 +677,7 @@ class WhatsappActions(AndroidAppiumActions):
         "/hierarchy/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.ListView/android.widget.LinearLayout[5]/android.widget.LinearLayout").click()
         self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value="You").click()
 
+    @log_action
     def open_more_options(self):
         """
         Open more options (hamburger menu) in the home screen.
@@ -652,6 +685,7 @@ class WhatsappActions(AndroidAppiumActions):
         self.driver.find_element(by=AppiumBy.XPATH,
                                  value='//android.widget.ImageView[@content-desc="More options"]').click()
 
+    @log_action
     def open_view_once_photo(self, chat=None):
         """
         Open view once photo in the current or specified chat. Should be done right after the photo is sent, to ensure the correct photo is opened, this will be the lowest one.

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.8.0"
+version = "2.9.0"


### PR DESCRIPTION
In this PR, I added ground truth logging with decorator to each action. I made a distinction between the private functions and public functions. Only the public ones now have a decorator. 

Moreover, I changed the default logging config. When run from a notebook, a main within puma/apps/android, or from tests, the logging config of puma is automatically used.
When run from another package, eg your own scenario or a larger application, the puma logging helper function must be called, or the developer should configure logging theirselves. So, in the latter case the logging must be explicitly turned on