### PR TITLE
Fix for bookmarking pages and creating and switching to new tabs

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+Version 2.9.1
+-------------
+113. Fix for bookmarking and creating a new tab in Chrome
+
 Version 2.9.0
 -------------
 110. Add ground truth logging

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -51,11 +51,37 @@ class GoogleChromeActions(AndroidAppiumActions):
     def bookmark_page(self):
         """
         Bookmarks the current page.
+        :return: True if bookmark has been added, False if it already existed.
         """
         three_dots_xpath = '//android.widget.ImageButton[@content-desc="Customize and control Google Chrome"]'
         bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="bookmark"]'
+        edit_bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="edit bookmark"]'
         self.driver.find_element(by=AppiumBy.XPATH, value=three_dots_xpath).click()
-        self.driver.find_element(by=AppiumBy.XPATH, value=bookmark_xpath).click()
+        if self.is_present(edit_bookmark_xpath):
+            self.back()
+            return False
+        else:
+            self.driver.find_element(by=AppiumBy.XPATH, value=bookmark_xpath).click()
+            return True
+
+    @log_action
+    def delete_bookmark(self):
+        """
+        Delete the current bookmark.
+        :return: True if bookmark has been deleted, False if it wasn't bookmarked.
+        """
+        three_dots_xpath = '//android.widget.ImageButton[@content-desc="Customize and control Google Chrome"]'
+        bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="bookmark"]'
+        edit_bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="edit bookmark"]'
+        delete_bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="delete bookmarks"]'
+        self.driver.find_element(by=AppiumBy.XPATH, value=three_dots_xpath).click()
+        if self.is_present(bookmark_xpath):
+            self.back()
+            return False
+        else:
+            self.driver.find_element(by=AppiumBy.XPATH, value=edit_bookmark_xpath).click()
+            self.driver.find_element(by=AppiumBy.XPATH, value=delete_bookmark_xpath).click()
+            return True
 
     @log_action
     def load_bookmark(self):

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -7,7 +7,7 @@ from puma.apps.android.appium_actions import AndroidAppiumActions, supported_ver
 
 GOOGLE_CHROME_PACKAGE = 'com.android.chrome'
 
-@supported_version("138.0.7204.179")
+@supported_version("139.0.7258.62")
 class GoogleChromeActions(AndroidAppiumActions):
     def __init__(self,
                  device_udid,

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -7,7 +7,7 @@ from puma.apps.android.appium_actions import AndroidAppiumActions, supported_ver
 
 GOOGLE_CHROME_PACKAGE = 'com.android.chrome'
 
-@supported_version("124.0.6367.219")
+@supported_version("138.0.7204.179")
 class GoogleChromeActions(AndroidAppiumActions):
     def __init__(self,
                  device_udid,

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -34,8 +34,8 @@ class GoogleChromeActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.XPATH, value=search_box_xpath).click()
 
         if new_tab:
-            switch_tab_xpath = '//android.widget.ImageButton[contains(@content-desc, "Switch")]'
-            new_tab_xpath = '//android.widget.TextView[@resource-id="com.android.chrome:id/new_tab_view_desc"]'
+            switch_tab_xpath = '//android.widget.ImageButton[contains(@content-desc, "tabs")]'
+            new_tab_xpath = '//android.widget.Button[contains(@content-desc, "tab")]'
             self.driver.find_element(by=AppiumBy.XPATH, value=switch_tab_xpath).click()
             self.driver.find_element(by=AppiumBy.XPATH, value=new_tab_xpath).click()
             self.driver.find_element(by=AppiumBy.XPATH, value=search_box_xpath).click()
@@ -52,7 +52,7 @@ class GoogleChromeActions(AndroidAppiumActions):
         Bookmarks the current page.
         """
         three_dots_xpath = '//android.widget.ImageButton[@content-desc="Customize and control Google Chrome"]'
-        bookmark_xpath = '//android.widget.ImageButton[lower-case(@content-desc)="bookmark"]'
+        bookmark_xpath = '//android.widget.Button[lower-case(@content-desc)="bookmark"]'
         self.driver.find_element(by=AppiumBy.XPATH, value=three_dots_xpath).click()
         self.driver.find_element(by=AppiumBy.XPATH, value=bookmark_xpath).click()
 

--- a/puma/apps/android/google_chrome/google_chrome.py
+++ b/puma/apps/android/google_chrome/google_chrome.py
@@ -34,10 +34,11 @@ class GoogleChromeActions(AndroidAppiumActions):
             self.driver.find_element(by=AppiumBy.XPATH, value=search_box_xpath).click()
 
         if new_tab:
-            switch_tab_xpath = '//android.widget.ImageButton[contains(@content-desc, "tabs")]'
+            switch_tab_xpath = '//android.widget.ImageButton[@resource-id="com.android.chrome:id/tab_switcher_button"]'
             new_tab_xpath = '//android.widget.Button[contains(@content-desc, "tab")]'
             self.driver.find_element(by=AppiumBy.XPATH, value=switch_tab_xpath).click()
             self.driver.find_element(by=AppiumBy.XPATH, value=new_tab_xpath).click()
+            self.is_present(xpath=switch_tab_xpath, implicit_wait=1)
             self.driver.find_element(by=AppiumBy.XPATH, value=search_box_xpath).click()
 
         url_bar_xpath = '//android.widget.EditText[@resource-id="com.android.chrome:id/url_bar"]'

--- a/puma/version.py
+++ b/puma/version.py
@@ -1,1 +1,1 @@
-version = "2.9.0"
+version = "2.9.1"

--- a/test_scripts/test_google_chrome.py
+++ b/test_scripts/test_google_chrome.py
@@ -32,14 +32,20 @@ class TestGoogleChrome(unittest.TestCase):
     def test_new_tab(self):
         self.alice.go_to("www.google.com", new_tab=True)
 
-    def test_save_bookmark(self):
+    def test_bookmarks(self):
         self.alice.go_to("www.wikipedia.com")
-        self.alice.bookmark_page()
+        # Clean up at the start, so we can be sure that both saving and deleting are properly tested.
+        self.alice.delete_bookmark()
 
-    def test_load_bookmark(self):
+        self.assertTrue(self.alice.bookmark_page())
+        self.assertFalse(self.alice.bookmark_page())
         self.alice.load_bookmark()
+        self.assertTrue(self.alice.delete_bookmark())
+        self.assertFalse(self.alice.delete_bookmark())
 
-    def test_incognito(self):
+    # This test contains 'zzz' to make sure it runs last. This should be fixed later.
+    # Other tests fail if Chrome is left in incognito mode. This should be made more robust.
+    def test_zzz_incognito(self):
         self.alice.go_to_incognito("www.wikipedia.com")
 
 

--- a/test_scripts/test_google_chrome.py
+++ b/test_scripts/test_google_chrome.py
@@ -33,6 +33,7 @@ class TestGoogleChrome(unittest.TestCase):
         self.alice.go_to("www.google.com", new_tab=True)
 
     def test_save_bookmark(self):
+        self.alice.go_to("www.wikipedia.com")
         self.alice.bookmark_page()
 
     def test_load_bookmark(self):


### PR DESCRIPTION
This pull request contains a fix for two Google Chrome functions:
- bookmarking pages (brought to our attention in issue #113 )
- creating and switching to a new tab

These issues were created by changed XPATHs.